### PR TITLE
Change installer.php to be able to handle using of old db driver and sql statements

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2016-02-26.sql
@@ -9,6 +9,6 @@
 
 CREATE TABLE IF NOT EXISTS `#__utf8_conversion` (
   `converted` tinyint(4) NOT NULL DEFAULT 0
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 DEFAULT COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 INSERT INTO `#__utf8_conversion` (`converted`) VALUES (0);

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -854,20 +854,50 @@ class JInstaller extends JAdapter
 			return 0;
 		}
 
+		$dbDriver = strtolower($db->name);
+
+		$doUtf8mb4ToUtf8 = !$this->serverClaimsUtf8mb4Support($dbDriver);
+
+		if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
+		{
+			$dbDriver = 'mysql';
+		}
+
+		if ($dbDriver != 'mysql')
+		{
+			$doUtf8mb4ToUtf8 = false;
+		}
+
+		$update_count = 0;
+
 		// Process each query in the $queries array (children of $tagName).
 		foreach ($queries as $query)
 		{
-			$db->setQuery($query->data());
-
-			if (!$db->execute())
+			if ($trimmedQuery = $this->trimQuery($query->data()))
 			{
-				JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $db->stderr(true)), JLog::WARNING, 'jerror');
+				/**
+				 * If we don't have UTF-8 Multibyte support on mysql we'll have to
+				 *convert queries to plain UTF-8
+				 */
+				if ($doUtf8mb4ToUtf8)
+				{
+					$trimmedQuery = $this->convertUtf8mb4QueryToUtf8($trimmedQuery);
+				}
 
-				return false;
+				$db->setQuery($trimmedQuery);
+
+				if (!$db->execute())
+				{
+					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_SQL_ERROR', $db->stderr(true)), JLog::WARNING, 'jerror');
+
+					return false;
+				}
+
+				$update_count++;
 			}
 		}
 
-		return (int) count($queries);
+		return $update_count;
 	}
 
 	/**
@@ -891,10 +921,19 @@ class JInstaller extends JAdapter
 		$db = & $this->_db;
 		$dbDriver = strtolower($db->name);
 
+		$doUtf8mb4ToUtf8 = !$this->serverClaimsUtf8mb4Support($dbDriver);
+
 		if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
 		{
 			$dbDriver = 'mysql';
 		}
+
+		if ($dbDriver != 'mysql')
+		{
+			$doUtf8mb4ToUtf8 = false;
+		}
+
+		$update_count = 0;
 
 		// Get the name of the sql file to process
 		foreach ($element->children() as $file)
@@ -941,28 +980,18 @@ class JInstaller extends JAdapter
 				// Process each query in the $queries array (split out of sql file).
 				foreach ($queries as $query)
 				{
-					$query = trim($query);
-
-					if ($query != '' && $query{0} != '#')
+					if ($trimmedQuery = $this->trimQuery($query))
 					{
 						/**
-						 * If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
-						 *
-						 * Note: the JDatabaseDriver::convertUtf8mb4QueryToUtf8 performs the conversion ONLY when
-						 * necessary, so there's no need to check the conditions in JInstaller.
+						 * If we don't have UTF-8 Multibyte support on mysql we'll have to
+						 *convert queries to plain UTF-8
 						 */
-						$query = $db->convertUtf8mb4QueryToUtf8($query);
-
-						/**
-						 * This is a query which was supposed to convert tables to utf8mb4 charset but the server doesn't
-						 * support utf8mb4. Therefore we don't have to run it, it has no effect and it's a mere waste of time.
-						 */
-						if (!$db->hasUTF8mb4Support() && stristr($query, 'CONVERT TO CHARACTER SET utf8 '))
+						if ($doUtf8mb4ToUtf8)
 						{
-							continue;
+							$trimmedQuery = $this->convertUtf8mb4QueryToUtf8($trimmedQuery);
 						}
 
-						$db->setQuery($query);
+						$db->setQuery($trimmedQuery);
 
 						if (!$db->execute())
 						{
@@ -970,12 +999,14 @@ class JInstaller extends JAdapter
 
 							return false;
 						}
+
+						$update_count++;
 					}
 				}
 			}
 		}
 
-		return (int) count($queries);
+		return $update_count;
 	}
 
 	/**
@@ -1071,9 +1102,16 @@ class JInstaller extends JAdapter
 			{
 				$dbDriver = strtolower($db->name);
 
+				$doUtf8mb4ToUtf8 = !$this->serverClaimsUtf8mb4Support($dbDriver);
+
 				if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
 				{
 					$dbDriver = 'mysql';
+				}
+
+				if ($dbDriver != 'mysql')
+				{
+					$doUtf8mb4ToUtf8 = false;
 				}
 
 				$schemapath = '';
@@ -1146,11 +1184,18 @@ class JInstaller extends JAdapter
 							// Process each query in the $queries array (split out of sql file).
 							foreach ($queries as $query)
 							{
-								$query = trim($query);
-
-								if ($query != '' && $query{0} != '#')
+								if ($trimmedQuery = $this->trimQuery($query))
 								{
-									$db->setQuery($query);
+									/**
+									 * If we don't have UTF-8 Multibyte support on mysql we'll have to
+									 *convert queries to plain UTF-8
+									 */
+									if ($doUtf8mb4ToUtf8)
+									{
+										$trimmedQuery = $this->convertUtf8mb4QueryToUtf8($trimmedQuery);
+									}
+
+									$db->setQuery($trimmedQuery);
 
 									if (!$db->execute())
 									{
@@ -1160,7 +1205,7 @@ class JInstaller extends JAdapter
 									}
 									else
 									{
-										$queryString = (string) $query;
+										$queryString = (string) $trimmedQuery;
 										$queryString = str_replace(array("\r", "\n"), array('', ' '), substr($queryString, 0, 80));
 										JLog::add(JText::sprintf('JLIB_INSTALLER_UPDATE_LOG_QUERY', $file, $queryString), JLog::INFO, 'Update');
 									}
@@ -2370,5 +2415,117 @@ class JInstaller extends JAdapter
 	public function loadAllAdapters($options = array())
 	{
 		$this->getAdapters($options);
+	}
+
+	/**
+	 * Does the database server claim to have support for UTF-8 Multibyte (utf8mb4) collation?
+	 * 
+	 * This is a modified version of the function in JDatabase::serverClaimsUtf8mb4Support() - it is
+	 * duplicated here for people upgrading from a version lower than 3.5.0 through extension manager
+	 * which will still have the old database driver loaded at this point.
+	 *
+	 * @param   string  $format  The type of database connection.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.5.0
+	 */
+	private function serverClaimsUtf8mb4Support($format)
+	{
+		$db = JFactory::getDbo();
+
+		switch ($format)
+		{
+			case 'mysql':
+				$client_version = mysql_get_client_info();
+				$server_version = $db->getVersion();
+				break;
+			case 'mysqli':
+				$client_version = mysqli_get_client_info();
+				$server_version = $db->getVersion();
+				break;
+			case 'pdomysql':
+				$client_version = $db->getOption(PDO::ATTR_CLIENT_VERSION);
+				$server_version = $db->getOption(PDO::ATTR_SERVER_VERSION);
+				break;
+			default:
+				$client_version = false;
+				$server_version = false;
+		}
+
+		if ($client_version && version_compare($server_version, '5.5.3', '>='))
+		{
+			if (strpos($client_version, 'mysqlnd') !== false)
+			{
+				$client_version = preg_replace('/^\D+([\d.]+).*/', '$1', $client_version);
+
+				return version_compare($client_version, '5.0.9', '>=');
+			}
+			else
+			{
+				return version_compare($client_version, '5.5.3', '>=');
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Downgrade a CREATE TABLE or ALTER TABLE query from utf8mb4 (UTF-8 Multibyte) to plain utf8. Used when the server
+	 * doesn't support UTF-8 Multibyte.
+	 *
+	 * This is a modified version of the function in JDatabase::convertUtf8mb4QueryToUtf8() - it is duplicated here for
+	 * people upgrading from a version lower than 3.5.0 through installer which will still have the old database
+	 * driver loaded at this point. This is missing the check for utf8mb4 in JDatabaseDriver we make this check in the
+	 * updater elsewhere.
+	 *
+	 * @param   string  $query  The query to convert
+	 *
+	 * @return  string  The converted query
+	 */
+	private function convertUtf8mb4QueryToUtf8($query)
+	{
+		// If it's not an ALTER TABLE or CREATE TABLE command there's nothing to convert
+		$beginningOfQuery = substr($query, 0, 12);
+		$beginningOfQuery = strtoupper($beginningOfQuery);
+
+		if (!in_array($beginningOfQuery, array('ALTER TABLE ', 'CREATE TABLE')))
+		{
+			return $query;
+		}
+
+		// Replace utf8mb4 with utf8
+		return str_replace('utf8mb4', 'utf8', $query);
+	}
+
+	/**
+	 * Trim comment and blank lines out of a query string
+	 *
+	 * @param   string  $query  query string to be trimmed
+	 *
+	 * @return  string  String with leading comment lines removed
+	 *
+	 * @since   3.5
+	 */
+	private function trimQuery($query)
+	{
+		$query = trim($query);
+
+		while (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--' || substr($query, 0, 2) == '/*')
+		{
+			$endChars = (substr($query, 0, 1) == '#' || substr($query, 0, 2) == '--') ? "\n" : "*/";
+
+			if ($position = strpos($query, $endChars))
+			{
+				$query = trim(substr($query, $position + strlen($endChars)));
+			}
+			else
+			{
+				// If no newline, the rest of the file is a comment, so return an empty string.
+				return '';
+			}
+		}
+
+		return trim($query);
 	}
 }


### PR DESCRIPTION
#### Summary of Changes

I've experimented here a bit with the query downgrade and so on in installer.php and seen there was also a problem with comment lines before statements, and so I added stuff from script.php locally there, too, and added query downgrade wherever necessary now or in future.

The result now is that all works well for the update component, but the extension installer seems to fail because it is running the old installer.php.

Can this be?

You can use this PR here and merge, or you can leave it open just for documentation / discussion purpose.

Maybe not all the changes I made were necessary, e.g. the local versions of functions like the query downgrade or the utf8mb4 support check.

And so maybe not merge it but use it as base for later changes.

Let me know what you think when you find some time.