### PR TITLE
encode nonce with base64

### DIFF
--- a/plugins/system/httpheaders/httpheaders.php
+++ b/plugins/system/httpheaders/httpheaders.php
@@ -131,7 +131,7 @@ class PlgSystemHttpHeaders extends CMSPlugin implements SubscriberInterface
 			$this->app->setHeader('Referrer-Policy', $referrerpolicy);
 		}
 
-		$nonce = bin2hex(random_bytes(64));
+		$nonce = base64_encode(bin2hex(random_bytes(64)));
 		JFactory::getApplication()->set('script_nonce', $nonce);
 		JFactory::getApplication()->setHeader('Content-Security-Policy', 'default-src \'none\'; style-src \'self\' \'unsafe-inline\' https://fonts.googleapis.com/; script-src \'self\' \'nonce-' . $nonce . '\'; font-src \'self\' https://fonts.gstatic.com; img-src \'self\'; connect-src \'self\'; frame-src \'self\'', true);
 	}


### PR DESCRIPTION
### Summary of Changes

encode nonce with base64

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src

```
'nonce-<base64-value>'
```