### PR TITLE
Create new content records with null value for published up and down

### DIFF
--- a/administrator/components/com_content/Model/ArticleModel.php
+++ b/administrator/components/com_content/Model/ArticleModel.php
@@ -337,7 +337,7 @@ class ArticleModel extends AdminModel
 
 		if ($table->state == Workflow::CONDITION_PUBLISHED && intval($table->publish_down) == 0)
 		{
-			$table->publish_down = $this->getDbo()->getNullDate();
+			$table->publish_down = null;
 		}
 
 		// Increment the content version number.

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -273,12 +273,6 @@ class Content extends Table
 			$this->publish_down = $temp;
 		}
 
-		// Set modified to created date if not set
-		if (!$this->modified)
-		{
-			$this->modified = $this->created;
-		}
-
 		// Clean up keywords -- eliminate extra spaces between phrases
 		// and cr (\r) and lf (\n) characters from string
 		if (!empty($this->metakey))
@@ -344,6 +338,12 @@ class Content extends Table
 			if (empty($this->created_by))
 			{
 				$this->created_by = $user->get('id');
+			}
+
+			// Set modified to created date if not set
+			if (!$this->modified)
+			{
+				$this->modified = $this->created;
 			}
 		}
 

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -252,20 +252,20 @@ class Content extends Table
 			$this->hits = 0;
 		}
 
-		// Set publish_up to null date if not set
+		// Set publish_up to null if not set
 		if (!$this->publish_up)
 		{
-			$this->publish_up = $this->_db->getNullDate();
+			$this->publish_up = null;
 		}
 
-		// Set publish_down to null date if not set
+		// Set publish_down to null if not set
 		if (!$this->publish_down)
 		{
-			$this->publish_down = $this->_db->getNullDate();
+			$this->publish_down = null;
 		}
 
 		// Check the publish down date is not earlier than publish up.
-		if ($this->publish_down < $this->publish_up && $this->publish_down > $this->_db->getNullDate())
+		if (!is_null($this->publish_up) && !is_null($this->publish_down) && $this->publish_down < $this->publish_up)
 		{
 			// Swap the dates.
 			$temp = $this->publish_up;
@@ -273,10 +273,10 @@ class Content extends Table
 			$this->publish_down = $temp;
 		}
 
-		// Set modified to null date if not set
+		// Set modified to created date if not set
 		if (!$this->modified)
 		{
-			$this->modified = $this->_db->getNullDate();
+			$this->modified = $this->created;
 		}
 
 		// Clean up keywords -- eliminate extra spaces between phrases
@@ -321,7 +321,7 @@ class Content extends Table
 	 *
 	 * @since   1.6
 	 */
-	public function store($updateNulls = false)
+	public function store($updateNulls = true)
 	{
 		$date = Factory::getDate();
 		$user = Factory::getUser();


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/26295](https://github.com/joomla/joomla-cms/pull/26295).

Changes done in the same way as in [https://github.com/joomla/joomla-cms/pull/24675](https://github.com/joomla/joomla-cms/pull/24675) for com_contact and partly taken from Hannes' PR [https://github.com/joomla/joomla-cms/pull/25760](https://github.com/joomla/joomla-cms/pull/25760).

This makes sure new articles are created with null value for all nullable columns and sets the modified time to created time if it is null.