### PR TITLE
[4.0] Update the help output and comments of the deleted file check to folder use

### DIFF
--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -4,13 +4,13 @@
  *
  * This script requires one parameter:
  *
- * --from - The folder with the Joomla files to use as the starting point for the comparison.
+ * --from - The directory with the Joomla files to use as the starting point for the comparison.
  *
  * This script has one additional optional parameter:
  *
- * --to - The folder with the Joomla files to use as the ending point for the comparison.
+ * --to - The directory with the Joomla files to use as the ending point for the comparison.
  *
- * The reference parameters must be a folder containing an unpacked installation package of the CMS
+ * The reference parameters must be a directory containing an unpacked installation package of the CMS
  *
  * @package    Joomla.Build
  *
@@ -27,8 +27,8 @@ function usage($command)
 {
 	echo PHP_EOL;
 	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
-	echo PHP_TAB . '--from <ref>:' . PHP_TAB . 'Starting folder' . PHP_EOL;
-	echo PHP_TAB . '--to <ref>:' . PHP_TAB . 'Ending folder [optional]' . PHP_EOL;
+	echo PHP_TAB . '--from <ref>:' . PHP_TAB . 'Starting directory' . PHP_EOL;
+	echo PHP_TAB . '--to <ref>:' . PHP_TAB . 'Ending directory [optional]' . PHP_EOL;
 	echo PHP_EOL;
 }
 

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -4,13 +4,13 @@
  *
  * This script requires one parameter:
  *
- * --from - The git commit reference to use as the starting point for the comparison.
+ * --from - The folder with the Joomla files to use as the starting point for the comparison.
  *
  * This script has one additional optional parameter:
  *
- * --to - The git commit reference to use as the ending point for the comparison.
+ * --to - The folder with the Joomla files to use as the ending point for the comparison.
  *
- * The reference parameters may be any valid identifier (i.e. a branch, tag, or commit SHA)
+ * The reference parameters must be a folder containing an unpacked installation package of the CMS
  *
  * @package    Joomla.Build
  *
@@ -27,8 +27,8 @@ function usage($command)
 {
 	echo PHP_EOL;
 	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
-	echo PHP_TAB . '--from <ref>:' . PHP_TAB . 'Starting commit reference (branch/tag)' . PHP_EOL;
-	echo PHP_TAB . '--to <ref>:' . PHP_TAB . 'Ending commit reference (branch/tag) [optional]' . PHP_EOL;
+	echo PHP_TAB . '--from <ref>:' . PHP_TAB . 'Starting folder' . PHP_EOL;
+	echo PHP_TAB . '--to <ref>:' . PHP_TAB . 'Ending folder [optional]' . PHP_EOL;
 	echo PHP_EOL;
 }
 
@@ -38,7 +38,7 @@ function usage($command)
 
 $options = getopt('', array('from:', 'to::'));
 
-// We need the from reference, otherwise we're doomed to fail
+// We need the from folder, otherwise we're doomed to fail
 if (empty($options['from']))
 {
 	echo PHP_EOL;
@@ -49,7 +49,7 @@ if (empty($options['from']))
 	exit(1);
 }
 
-// Missing the to reference?  No problem, grab the current HEAD
+// Missing the to folder?  No problem, grab the current HEAD
 if (empty($options['to']))
 {
 	echo PHP_EOL;

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -38,7 +38,7 @@ function usage($command)
 
 $options = getopt('', array('from:', 'to::'));
 
-// We need the from folder, otherwise we're doomed to fail
+// We need the from directory, otherwise we're doomed to fail
 if (empty($options['from']))
 {
 	echo PHP_EOL;
@@ -49,7 +49,7 @@ if (empty($options['from']))
 	exit(1);
 }
 
-// Missing the to folder?  No problem, grab the current HEAD
+// Missing the to directory?  No problem, grab the current HEAD
 if (empty($options['to']))
 {
 	echo PHP_EOL;


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/25559](https://github.com/joomla/joomla-cms/pull/25559).

### Summary of Changes

When a parameter is missing, the help message which is shown in that case still talks about commit references to be used and not folders or directories.

I've deficed to use the wording "directory" at the end because in some help messages for missing parameters it was already used like this.

Some code comments do the same.

### Testing Instructions

Code review.

### Expected result

Correct comments and help output.

### Actual result

Misleading comments and help output.

### Documentation Changes Required

None.