### PR TITLE
Ensure array keys are reset for any values removed

### DIFF
--- a/administrator/components/com_finder/Indexer/Helper.php
+++ b/administrator/components/com_finder/Indexer/Helper.php
@@ -113,7 +113,10 @@ class Helper
 
 		$tokens = array();
 		$terms = $language->tokenise($input);
+
+		// TODO: array_filter removes any number 0's from the terms. Not sure this is entirely intended
 		$terms = array_filter($terms);
+		$terms = array_values($terms);
 
 		/*
 		 * If we have to handle the input as a phrase, that means we don't


### PR DESCRIPTION
### Summary of Changes
Fixes finder indexing certain values


### Testing Instructions
Create title of article "Overload sample 0 in 1"


### Expected result
Article saves


### Actual result
PHP Notice for an undefined key (you may need to look at your PHP Error log to find it) as the 0's are stripped and then the term count is wrong.


### Documentation Changes Required
None
