### PR TITLE
Use alternative method to click radio button switcher

### DIFF
--- a/tests/Codeception/acceptance/administrator/components/com_users/UserListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_users/UserListCest.php
@@ -148,9 +148,8 @@ class UserListCest
 		$I->waitForText('Global Configuration', $I->getConfig('timeout'), ['css' => '.page-title']);
 		$I->comment('I open the Server Tab');
 		$I->click('Server');
-		$I->comment('I wait for send mail radio button');
-		$I->wait(0.5);
-		$I->click(['xpath' => "//input[@type='radio' and @value=0 and @name='jform[mailonline]']"]);
+		$I->comment('I click on the switcher to disable sending mails');
+		$I->waitForJS('document.evaluate("//input[@type=\'radio\' and @value=0 and @name=\'jform[mailonline]\']", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.click();return true;');
 		$I->comment('I click on save');
 		$I->clickToolbarButton("Save");
 		$I->comment('I wait for global configuration being saved');


### PR DESCRIPTION
The switcher has an opacity of 0, which is why Codeception seems to classify this as non-interactable. This change should use an alternative method to trigger the click.