### PR TITLE
[CMS PR 25559] Don't remove previous releases' sample data images

### DIFF
--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -64,6 +64,7 @@ if (empty($options['to']))
 $previousReleaseExclude = [
 	$options['from'] . '/administrator/components/com_search',
 	$options['from'] . '/components/com_search',
+	$options['from'] . '/images/sampledata',
 	$options['from'] . '/modules/mod_search',
 	$options['from'] . '/plugins/search',
 	$options['from'] . '/plugins/fields/repeatable',


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/25559 .

### Summary of Changes

Old J3 sample data images are not included anymore in the build, see https://github.com/joomla/joomla-cms/pull/32009 .

So when using the script to get the lists of files and folder to be deleted on the full packages zip files, these images will appear in the list.

This PR here adds them to the exclusion list for that.

Discussion about removing them from source code see https://github.com/joomla/joomla-cms/discussions/32744 .

In the discussion it was agreed not to remove them from old sites on updates.