### PR TITLE
[CMS PR 25559] Handle files which have been renamed only

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -12,3 +12,4 @@
 # Ignore the deleted file script output
 /deleted_files.txt
 /deleted_folders.txt
+/renamed_files.txt

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -200,7 +200,7 @@ foreach ($filesDifference as $file)
 			if (dirname($match) === dirname($file) && strtolower(basename($match)) === strtolower(basename($file)))
 			{
 				// File has been renamed only: Add to renamed files list
-				$renamedFiles[] = $file . ' => ' . $match;
+				$renamedFiles[] = substr($file, 0, -1) . ' => ' . $match;
 
 				// Go on with the next file in $filesDifference
 				continue 2;

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -149,8 +149,8 @@ $filesDifference = array_diff($previousReleaseFiles, $newReleaseFiles);
 
 $foldersDifference = array_diff($previousReleaseFolders, $newReleaseFolders);
 
-// Remove any specific files (e.g. language files) that we want to keep on upgrade
-$filesToRemove = [
+// Specific files (e.g. language files) that we want to keep on upgrade
+$filesToKeep = [
 	"'/administrator/language/en-GB/en-GB.com_search.ini',",
 	"'/administrator/language/en-GB/en-GB.com_search.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_fields_repeatable.ini',",
@@ -176,19 +176,45 @@ $filesToRemove = [
 	"'/language/en-GB/en-GB.mod_search.sys.ini',",
 ];
 
-foreach ($filesToRemove as $file)
-{
-	if (($key = array_search($file, $filesDifference)) !== false) {
-		unset($filesDifference[$key]);
-	}
-}
-
 asort($filesDifference);
 rsort($foldersDifference);
 
-// Write the deleted files list to a file for later reference
-file_put_contents(__DIR__ . '/deleted_files.txt', implode("\n", $filesDifference));
+$deletedFiles = [];
+$renamedFiles = [];
+
+foreach ($filesDifference as $file)
+{
+	// Don't remove any specific files (e.g. language files) that we want to keep on upgrade
+	if (array_search($file, $filesToKeep) !== false)
+	{
+		continue;
+	}
+
+	// Check for files which might have been renamed only
+	$matches = preg_grep('/^' . preg_quote($file, '/') . '$/i', $newReleaseFiles);
+
+	if ($matches !== false)
+	{
+		foreach ($matches as $match)
+		{
+			if (dirname($match) === dirname($file) && strtolower(basename($match)) === strtolower(basename($file)))
+			{
+				// File has been renamed only: Add to renamed files list
+				$renamedFiles[] = $file . ' => ' . $match;
+
+				// Go on with the next file in $filesDifference
+				continue 2;
+			}
+		}
+	}
+
+	$deletedFiles[] = $file;
+}
+
+// Write the lists to files for later reference
+file_put_contents(__DIR__ . '/deleted_files.txt', implode("\n", $deletedFiles));
 file_put_contents(__DIR__ . '/deleted_folders.txt', implode("\n", $foldersDifference));
+file_put_contents(__DIR__ . '/renamed_files.txt', implode("\n", $renamedFiles));
 
 echo PHP_EOL;
-echo 'There are ' . count($filesDifference) . ' deleted files and ' . count($foldersDifference) .  ' deleted folders in comparison to "' . $options['from'] . '"' . PHP_EOL;
+echo 'There are ' . count($deletedFiles) . ' deleted files, ' . count($foldersDifference) .  ' deleted folders and ' . count($renamedFiles) .  ' renamed files in comparison to "' . $options['from'] . '"' . PHP_EOL;

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -208,6 +208,7 @@ foreach ($filesDifference as $file)
 		}
 	}
 
+	// File has been really deleted and not just renamed
 	$deletedFiles[] = $file;
 }
 


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/25559 .

### Summary of Changes

Files which have been renamed only shall not be in the list of files to be deleted.

A separate list shall be created for these instead, containing both the old and the new full path.

Renamed means they have base name with different upper or lower case, but everything else is the same, i.e. the directory is the same, case-sensitive.

In the same way as it is with the already existing lists, it can be that from one release to the other a file is renamed from "A" to "a", and then later again from "a" to "A".

Currently this happens when comparing 4.0 Beta 1 with 3.10 last nightly, which results in the rename like this:

'/libraries/src/Filesystem/Support/StringController.php' => '/libraries/src/Filesystem/Support/Stringcontroller.php'

And later when comparing 4.0 Beta 7 with Beta 6, we get:

'/libraries/src/Filesystem/Support/Stringcontroller.php' => '/libraries/src/Filesystem/Support/StringController.php'

But this can also happen with the list of deleted files when a file has been deleted and later is added back: It has to be checked with the previous release's comparion.