### PR TITLE
[CMS PR 25559] Add list of folders to keep on update

### DIFF
--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -183,7 +183,7 @@ $foldersToKeep = [
 	"'/libraries/vendor/bin',",
 ];
 
-// Don't remove any specific folders that we want to keep on upgrade
+// Remove folders from the results which we want to keep on upgrade
 foreach ($foldersToKeep as $folder)
 {
 	if (($key = array_search($folder, $foldersDifference)) !== false) {

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -177,6 +177,20 @@ $filesToKeep = [
 	"'/language/en-GB/en-GB.mod_search.sys.ini',",
 ];
 
+// Specific folders that we want to keep on upgrade
+$foldersToKeep = [
+	"'/bin',",
+	"'/libraries/vendor/bin',",
+];
+
+// Don't remove any specific folders that we want to keep on upgrade
+foreach ($foldersToKeep as $folder)
+{
+	if (($key = array_search($folder, $foldersDifference)) !== false) {
+		unset($foldersDifference[$key]);
+	}
+}
+
 asort($filesDifference);
 rsort($foldersDifference);
 

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -180,7 +180,6 @@ $filesToKeep = [
 // Specific folders that we want to keep on upgrade
 $foldersToKeep = [
 	"'/bin',",
-	"'/libraries/vendor/bin',",
 ];
 
 // Remove folders from the results which we want to keep on upgrade


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/25559 .

### Summary of Changes

Make sure we don't delete certain folders on update even if we deleted everything inside them, as long as we don't have a "Folder::DeleteIfEmpty" in the framework's filesystem package.

Currently these are the `/bin` and `/libraries/vendor/bin` folders, see also https://github.com/joomla/joomla-cms/pull/34289 .

### Testing Instructions

Use your tool with and without this PR and compare the difference between the results.

The only difference is that the 2 folders mentioned above are missing in the list of folders to be deleted.